### PR TITLE
Added Brightness control

### DIFF
--- a/Classes/Filter.cs
+++ b/Classes/Filter.cs
@@ -7,7 +7,7 @@ namespace Penumbra.Classes
 	/// <summary>
 	/// Class for manipulating the brightness of the screen
 	/// </summary>
-	public static class Brightness
+	public static class Filter
 	{
 
 #region Consts
@@ -45,6 +45,11 @@ namespace Penumbra.Classes
 
 		[DllImport("gdi32.dll")]
 		static extern bool SetDeviceGammaRamp(IntPtr hdc, ref RAMP lpRamp);
+                
+        [DllImport("Dxva2.dll")]
+        static extern bool SetMonitorBrightness(IntPtr hMonitor, uint dwNewBrightness );
+
+
 
 // ReSharper restore InconsistentNaming
 #endregion
@@ -61,10 +66,10 @@ namespace Penumbra.Classes
 
 #region Ctors
 
-		static Brightness()
+		static Filter()
 		{
-
-			GetDeviceGammaRamp(GetDC(IntPtr.Zero), ref m_InitialRAMP);
+            //IntPtr ptr = IntPtr.Add(IntPtr.Zero, 1);
+            GetDeviceGammaRamp(GetDC(IntPtr.Zero), ref m_InitialRAMP);
 
 			m_CurrentBrightness = GetBrightnessFromRAMP(m_InitialRAMP);
 
@@ -84,10 +89,9 @@ namespace Penumbra.Classes
 
 			RAMP c_Ramp = CalculateRAMP(p_Brightness);
 
-			SetDeviceGammaRamp(GetDC(IntPtr.Zero), ref c_Ramp);
+            SetDeviceGammaRamp(GetDC(IntPtr.Zero), ref c_Ramp);
 
 			return true;
-
 		}
 
 		public static void ResetBrightness()

--- a/Classes/Filter.cs
+++ b/Classes/Filter.cs
@@ -68,7 +68,6 @@ namespace Penumbra.Classes
 
 		static Filter()
 		{
-            //IntPtr ptr = IntPtr.Add(IntPtr.Zero, 1);
             GetDeviceGammaRamp(GetDC(IntPtr.Zero), ref m_InitialRAMP);
 
 			m_CurrentBrightness = GetBrightnessFromRAMP(m_InitialRAMP);

--- a/Classes/Monitor.cs
+++ b/Classes/Monitor.cs
@@ -168,10 +168,9 @@ namespace Penumbra
         }
         public void SetBrightness(int brightness)
         {
-            //todo get the normalized brightness
             foreach (Monitor monitor in hMonitorList)
             {
-                bool isIt = SetMonitorBrightness(monitor.hMonitor, brightness);
+                SetMonitorBrightness(monitor.hMonitor, CalculateBrightness(brightness, monitor));
                 int lastWin32Error = Marshal.GetLastWin32Error();
             }
         }
@@ -259,6 +258,12 @@ namespace Penumbra
             
             return monitorResult;
         }
+
+        private int CalculateBrightness(int inBrightness, Monitor hMonitor)
+        {
+            return (int)hMonitor.brightness.min + ((int)((float)(hMonitor.brightness.max - hMonitor.brightness.min) * ((float)inBrightness / 100))); 
+        }
+
 
 #endregion
 

--- a/Monitor.cs
+++ b/Monitor.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Collections;
+
+namespace Penumbra
+{
+    class Monitors
+    {
+
+        [DllImport("user32.dll")]
+        static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumDelegate lpfnEnum, IntPtr dwData);
+
+        delegate bool MonitorEnumDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData);
+
+        [DllImport("Dxva2.dll")]
+        static extern bool SetMonitorBrightness(IntPtr hMonitor,
+                                                int dwNewBrightness);
+
+        [DllImport("Dxva2.dll")]
+        static extern bool GetMonitorBrightness([In] IntPtr hMonitor,
+                                               ref uint pdwMinimumBrightness,
+                                               ref uint pdwCurrentBrightness,
+                                               ref uint pdwMaximumBrightness);
+
+        [DllImport("kernel32.dll")]
+        public static extern uint GetLastError();
+
+        [DllImport("dxva2.dll", EntryPoint = "GetPhysicalMonitorsFromHMONITOR")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetPhysicalMonitorsFromHMONITOR(
+            IntPtr hMonitor, uint dwPhysicalMonitorArraySize, [Out] PHYSICAL_MONITOR[] pPhysicalMonitorArray);
+
+        [DllImport("dxva2.dll", EntryPoint = "GetNumberOfPhysicalMonitorsFromHMONITOR", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetNumberOfPhysicalMonitorsFromHMONITOR(
+            IntPtr hMonitor, ref uint pdwNumberOfPhysicalMonitors);
+
+        [DllImport("dxva2.dll", EntryPoint = "DestroyPhysicalMonitors", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool DestroyPhysicalMonitors(
+            uint dwPhysicalMonitorArraySize, [Out] PHYSICAL_MONITOR[] pPhysicalMonitorArray);
+
+        [DllImport("dxva2.dll", EntryPoint = "GetMonitorTechnologyType", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetMonitorTechnologyType(
+            IntPtr hMonitor, ref MC_DISPLAY_TECHNOLOGY_TYPE pdtyDisplayTechnologyType);
+
+        [DllImport("dxva2.dll", EntryPoint = "GetMonitorCapabilities", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetMonitorCapabilities(
+            IntPtr hMonitor, ref uint pdwMonitorCapabilities, ref uint pdwSupportedColorTemperatures);
+
+        static ArrayList hMonitorList = new ArrayList();
+
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Rect
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        public struct Monitor
+        {
+            public IntPtr hMonitor;
+            public Brightness brightness;
+            public Monitor init()
+            {
+                brightness = brightness.init();
+                return this;
+            }
+        }
+        public struct Brightness
+        {
+            public uint current;
+            public uint min;
+            public uint max;
+
+            public Brightness init()
+            {
+                  current = 0;
+                  min = 0;
+                  max = 0;
+                  return this;
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct PHYSICAL_MONITOR
+        {
+            public IntPtr hPhysicalMonitor;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string szPhysicalMonitorDescription;
+        }
+
+        public static int getBrightness()
+        {
+            return Convert.ToInt32(((Monitor)hMonitorList[0]).brightness.current);
+        }
+
+        private static bool initBrightness(IntPtr hMonitor)
+        {
+
+            Monitor monitor = new Monitor().init();
+
+            bool hasBrightness = GetMonitorBrightness(hMonitor, ref monitor.brightness.min, ref monitor.brightness.current, ref monitor.brightness.max);
+            uint error = GetLastError();
+
+            if (hasBrightness)
+            {
+                monitor.hMonitor = hMonitor;
+                hMonitorList.Add(monitor);
+            }
+            return hasBrightness;
+        }
+
+        public static void setBrightness(int brightness)
+        {
+            //todo get the normalized brightness
+            foreach (Monitor monitor in hMonitorList)
+            {
+                bool isIt = SetMonitorBrightness(monitor.hMonitor, brightness);
+                int lastWin32Error = Marshal.GetLastWin32Error();
+            }
+        }
+
+        public enum MC_DISPLAY_TECHNOLOGY_TYPE
+        {
+            MC_SHADOW_MASK_CATHODE_RAY_TUBE,
+            MC_APERTURE_GRILL_CATHODE_RAY_TUBE,
+            MC_THIN_FILM_TRANSISTOR,
+            MC_LIQUID_CRYSTAL_ON_SILICON,
+            MC_PLASMA,
+            MC_ORGANIC_LIGHT_EMITTING_DIODE,
+            MC_ELECTROLUMINESCENT,
+            MC_MICROELECTROMECHANICAL,
+            MC_FIELD_EMISSION_DEVICE,
+        }
+
+
+        public static void init()
+        {
+            GetDisplays();
+        }
+
+        public static Boolean brightnessCapability()
+        {
+            return hMonitorList.Count > 0;
+        }
+
+        private static Tuple<bool, IntPtr> verifyMonitor(IntPtr inMonitor)
+        {
+
+            IntPtr hMonitor = inMonitor;
+            EnumDisplayMonitors(
+                inMonitor,
+                inMonitor,
+                delegate(IntPtr monitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData)
+                {
+                    hMonitor = monitor;
+                    return true;
+                },
+                inMonitor);
+
+            int lastWin32Error = Marshal.GetLastWin32Error();
+
+            uint pdwNumberOfPhysicalMonitors = 0u;
+            bool numberOfPhysicalMonitorsFromHmonitor = GetNumberOfPhysicalMonitorsFromHMONITOR(
+                hMonitor, ref pdwNumberOfPhysicalMonitors);
+            lastWin32Error = Marshal.GetLastWin32Error();
+
+            PHYSICAL_MONITOR[] pPhysicalMonitorArray =
+                new PHYSICAL_MONITOR[pdwNumberOfPhysicalMonitors];
+            bool physicalMonitorsFromHmonitor = GetPhysicalMonitorsFromHMONITOR(
+                hMonitor, pdwNumberOfPhysicalMonitors, pPhysicalMonitorArray);
+            lastWin32Error = Marshal.GetLastWin32Error();
+
+            uint pdwMonitorCapabilities = 0u;
+            uint pdwSupportedColorTemperatures = 0u;
+            var monitorCapabilities = GetMonitorCapabilities(
+                pPhysicalMonitorArray[0].hPhysicalMonitor, ref pdwMonitorCapabilities, ref pdwSupportedColorTemperatures);
+            lastWin32Error = Marshal.GetLastWin32Error();
+
+            bool hasMonitorCapabilities = (((int)MC_CAPS_BRIGHTNESS & pdwMonitorCapabilities) > 0);
+
+            return new Tuple<bool, IntPtr>(hasMonitorCapabilities, pPhysicalMonitorArray[0].hPhysicalMonitor);// hMonitorList.Count > 0;
+        }
+
+        /// <summary>
+        /// Returns the number of Displays using the Win32 functions
+        /// </summary>
+        /// <returns>collection of Display Info</returns>
+        public static void GetDisplays()
+        {
+
+            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
+                delegate(IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData)
+                {
+                    Tuple<Boolean, IntPtr> result = verifyMonitor(hMonitor);
+
+                    if (result.Item1)
+                    {
+                        initBrightness(result.Item2);
+                    }
+
+                    return true;
+                }, IntPtr.Zero);
+
+        }
+
+        public const uint MC_CAPS_BRIGHTNESS = 0x00000002;
+
+    }
+}

--- a/Penumbra.csproj
+++ b/Penumbra.csproj
@@ -11,6 +11,21 @@
     <AssemblyName>Penumbra</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,7 +62,7 @@
     <Compile Include="Classes\Filter.cs" />
     <Compile Include="Classes\INI.cs" />
     <Compile Include="Classes\Screensaver.cs" />
-    <Compile Include="Monitor.cs" />
+    <Compile Include="Classes\Monitor.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Setup.cs" />
@@ -96,6 +111,28 @@
       <Project>{2A95D861-95F9-48FC-91DA-392A323B8366}</Project>
       <Name>PU_Keyboard</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.0">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.4.5">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 4.5</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Penumbra.csproj
+++ b/Penumbra.csproj
@@ -44,9 +44,10 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Classes\Brightness.cs" />
+    <Compile Include="Classes\Filter.cs" />
     <Compile Include="Classes\INI.cs" />
     <Compile Include="Classes\Screensaver.cs" />
+    <Compile Include="Monitor.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Setup.cs" />

--- a/Program.cs
+++ b/Program.cs
@@ -116,8 +116,13 @@ namespace Penumbra
 			// Check the initial filter state and act according it
 			//
 			if (Filtering)
-				Brightness.SetBrightness(FilterLevelToBrightness(byte.Parse(FilterLevel.ToString(CultureInfo.InvariantCulture))));
+				Filter.SetBrightness(FilterLevelToBrightness(byte.Parse(FilterLevel.ToString(CultureInfo.InvariantCulture))));
 
+            Monitors.init();
+            /*if (Monitor.brightnessCapability())
+            {
+                m_SettingsWindow.tb_BrightnessLevel.Enabled = false;
+            }*/
 			Application.Run();
 
 		}
@@ -134,7 +139,7 @@ namespace Penumbra
 
 				m_NotifyIcon.Icon = Properties.Resources.eye_off;
 
-				Brightness.ResetBrightness();
+				Filter.ResetBrightness();
 
 				m_HotkeyIncrease.Enabled = m_HotkeyDecrease.Enabled = false;
 
@@ -142,7 +147,8 @@ namespace Penumbra
 				{
 
 					m_SettingsWindow.InternalChangeInProgress = true;
-					m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.tb_FilterLevel.Enabled = false;
+                    m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.tb_FilterLevel.Enabled = false;
+                    m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.lb_FilterLevel.Enabled = false;
 					m_SettingsWindow.InternalChangeInProgress = false;
 
 				}
@@ -155,7 +161,7 @@ namespace Penumbra
 
 				m_NotifyIcon.Icon = Properties.Resources.eye_on;
 
-				Brightness.SetBrightness(FilterLevelToBrightness(byte.Parse(m_INI.ReadString(@"Filter", @"level"))));
+				Filter.SetBrightness(FilterLevelToBrightness(byte.Parse(m_INI.ReadString(@"Filter", @"level"))));
 
 				m_HotkeyIncrease.Enabled = m_HotkeyDecrease.Enabled = true;
 
@@ -163,6 +169,7 @@ namespace Penumbra
 				{
 
 					m_SettingsWindow.InternalChangeInProgress = true;
+                    m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.lb_FilterLevel.Enabled = true;
 					m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.tb_FilterLevel.Enabled = true;
 					m_SettingsWindow.InternalChangeInProgress = false;
 
@@ -206,7 +213,7 @@ namespace Penumbra
 			else if (p_FilterLevel > MAX_FILTER_LEVEL)
 				p_FilterLevel = MAX_FILTER_LEVEL;
 
-			Brightness.SetBrightness(FilterLevelToBrightness(p_FilterLevel));
+			Filter.SetBrightness(FilterLevelToBrightness(p_FilterLevel));
 
 			if (m_SettingsWindow != null)
 				m_SettingsWindow.tb_FilterLevel.Value = p_FilterLevel;
@@ -280,7 +287,7 @@ namespace Penumbra
 			m_NotifyIcon = null;
 
 			// Restore the old brightness
-			Brightness.Finalize();
+			Filter.Finalize();
 
 		}
 

--- a/Program.cs
+++ b/Program.cs
@@ -44,7 +44,7 @@ namespace Penumbra
 			get { return m_INI.ReadBoolean(@"Filter", @"active"); }
 
 			set { m_INI.WriteValue(@"Filter", @"active", (value ? "1" : "0")); }
-
+            //this will cause problems if the folder is readOnly
 		}
 
 		public static int FilterLevel
@@ -118,11 +118,8 @@ namespace Penumbra
 			if (Filtering)
 				Filter.SetBrightness(FilterLevelToBrightness(byte.Parse(FilterLevel.ToString(CultureInfo.InvariantCulture))));
 
-            Monitors.init();
-            /*if (Monitor.brightnessCapability())
-            {
-                m_SettingsWindow.tb_BrightnessLevel.Enabled = false;
-            }*/
+            Monitors.Instance.Init();
+
 			Application.Run();
 
 		}
@@ -148,8 +145,10 @@ namespace Penumbra
 
 					m_SettingsWindow.InternalChangeInProgress = true;
                     m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.tb_FilterLevel.Enabled = false;
-                    m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.lb_FilterLevel.Enabled = false;
-					m_SettingsWindow.InternalChangeInProgress = false;
+                    m_SettingsWindow.lb_FilterLevel.Enabled = false;
+                    m_SettingsWindow.tb_FilterLevel.Enabled = false;
+
+                    m_SettingsWindow.InternalChangeInProgress = false;
 
 				}
 
@@ -169,9 +168,10 @@ namespace Penumbra
 				{
 
 					m_SettingsWindow.InternalChangeInProgress = true;
-                    m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.lb_FilterLevel.Enabled = true;
 					m_SettingsWindow.cb_Filter.Checked = m_SettingsWindow.tb_FilterLevel.Enabled = true;
-					m_SettingsWindow.InternalChangeInProgress = false;
+                    m_SettingsWindow.lb_FilterLevel.Enabled = true;
+                    m_SettingsWindow.tb_FilterLevel.Enabled = true;
+                    m_SettingsWindow.InternalChangeInProgress = false;
 
 				}
 
@@ -179,7 +179,7 @@ namespace Penumbra
 
 			}
 
-			Filtering = !Filtering;
+            Filtering = !Filtering;
 
 		}
 
@@ -218,7 +218,7 @@ namespace Penumbra
 			if (m_SettingsWindow != null)
 				m_SettingsWindow.tb_FilterLevel.Value = p_FilterLevel;
 
-			m_INI.WriteValue(@"Filter", @"level", p_FilterLevel.ToString(CultureInfo.InvariantCulture));
+            m_INI.WriteValue(@"Filter", @"level", p_FilterLevel.ToString(CultureInfo.InvariantCulture));
 
 			m_NotifyIcon.Text = @"Penumbra - On (" + FilterLevel + @"%)";
 

--- a/Windows/SettingsWindow.Designer.cs
+++ b/Windows/SettingsWindow.Designer.cs
@@ -28,98 +28,103 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsWindow));
-			this.gb_Hotkeys = new System.Windows.Forms.GroupBox();
-			this.cb_QuitKey = new System.Windows.Forms.ComboBox();
-			this.cb_SettingsKey = new System.Windows.Forms.ComboBox();
-			this.cb_ToggleKey = new System.Windows.Forms.ComboBox();
-			this.cb_DecreaseKey = new System.Windows.Forms.ComboBox();
-			this.cb_IncreaseKey = new System.Windows.Forms.ComboBox();
-			this.cb_QuitAlt = new System.Windows.Forms.CheckBox();
-			this.cb_SettingsAlt = new System.Windows.Forms.CheckBox();
-			this.cb_ToggleAlt = new System.Windows.Forms.CheckBox();
-			this.cb_DecreaseAlt = new System.Windows.Forms.CheckBox();
-			this.cb_IncreaseAlt = new System.Windows.Forms.CheckBox();
-			this.cb_QuitShift = new System.Windows.Forms.CheckBox();
-			this.cb_SettingsShift = new System.Windows.Forms.CheckBox();
-			this.cb_ToggleShift = new System.Windows.Forms.CheckBox();
-			this.cb_DecreaseShift = new System.Windows.Forms.CheckBox();
-			this.cb_QuitCtrl = new System.Windows.Forms.CheckBox();
-			this.cb_SettingsCtrl = new System.Windows.Forms.CheckBox();
-			this.cb_ToggleCtrl = new System.Windows.Forms.CheckBox();
-			this.cb_DecreaseCtrl = new System.Windows.Forms.CheckBox();
-			this.cb_IncreaseShift = new System.Windows.Forms.CheckBox();
-			this.cb_IncreaseCtrl = new System.Windows.Forms.CheckBox();
-			this.label4 = new System.Windows.Forms.Label();
-			this.label3 = new System.Windows.Forms.Label();
-			this.label2 = new System.Windows.Forms.Label();
-			this.label1 = new System.Windows.Forms.Label();
-			this.lb_Key = new System.Windows.Forms.Label();
-			this.lb_Alt = new System.Windows.Forms.Label();
-			this.lb_Shift = new System.Windows.Forms.Label();
-			this.lb_Ctrl = new System.Windows.Forms.Label();
-			this.lb_Increase = new System.Windows.Forms.Label();
-			this.label5 = new System.Windows.Forms.Label();
-			this.gb_General = new System.Windows.Forms.GroupBox();
-			this.lb_FilterLevelMax = new System.Windows.Forms.Label();
-			this.lb_FilterLevelMin = new System.Windows.Forms.Label();
-			this.cb_Filter = new System.Windows.Forms.CheckBox();
-			this.label6 = new System.Windows.Forms.Label();
-			this.lb_FilterLevel = new System.Windows.Forms.Label();
-			this.tb_FilterLevel = new System.Windows.Forms.TrackBar();
-			this.gb_Hotkeys.SuspendLayout();
-			this.gb_General.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.tb_FilterLevel)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// gb_Hotkeys
-			// 
-			this.gb_Hotkeys.Controls.Add(this.cb_QuitKey);
-			this.gb_Hotkeys.Controls.Add(this.cb_SettingsKey);
-			this.gb_Hotkeys.Controls.Add(this.cb_ToggleKey);
-			this.gb_Hotkeys.Controls.Add(this.cb_DecreaseKey);
-			this.gb_Hotkeys.Controls.Add(this.cb_IncreaseKey);
-			this.gb_Hotkeys.Controls.Add(this.cb_QuitAlt);
-			this.gb_Hotkeys.Controls.Add(this.cb_SettingsAlt);
-			this.gb_Hotkeys.Controls.Add(this.cb_ToggleAlt);
-			this.gb_Hotkeys.Controls.Add(this.cb_DecreaseAlt);
-			this.gb_Hotkeys.Controls.Add(this.cb_IncreaseAlt);
-			this.gb_Hotkeys.Controls.Add(this.cb_QuitShift);
-			this.gb_Hotkeys.Controls.Add(this.cb_SettingsShift);
-			this.gb_Hotkeys.Controls.Add(this.cb_ToggleShift);
-			this.gb_Hotkeys.Controls.Add(this.cb_DecreaseShift);
-			this.gb_Hotkeys.Controls.Add(this.cb_QuitCtrl);
-			this.gb_Hotkeys.Controls.Add(this.cb_SettingsCtrl);
-			this.gb_Hotkeys.Controls.Add(this.cb_ToggleCtrl);
-			this.gb_Hotkeys.Controls.Add(this.cb_DecreaseCtrl);
-			this.gb_Hotkeys.Controls.Add(this.cb_IncreaseShift);
-			this.gb_Hotkeys.Controls.Add(this.cb_IncreaseCtrl);
-			this.gb_Hotkeys.Controls.Add(this.label4);
-			this.gb_Hotkeys.Controls.Add(this.label3);
-			this.gb_Hotkeys.Controls.Add(this.label2);
-			this.gb_Hotkeys.Controls.Add(this.label1);
-			this.gb_Hotkeys.Controls.Add(this.lb_Key);
-			this.gb_Hotkeys.Controls.Add(this.lb_Alt);
-			this.gb_Hotkeys.Controls.Add(this.lb_Shift);
-			this.gb_Hotkeys.Controls.Add(this.lb_Ctrl);
-			this.gb_Hotkeys.Controls.Add(this.lb_Increase);
-			this.gb_Hotkeys.Controls.Add(this.label5);
-			this.gb_Hotkeys.Location = new System.Drawing.Point(12, 123);
-			this.gb_Hotkeys.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-			this.gb_Hotkeys.Name = "gb_Hotkeys";
-			this.gb_Hotkeys.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
-			this.gb_Hotkeys.Size = new System.Drawing.Size(330, 237);
-			this.gb_Hotkeys.TabIndex = 1;
-			this.gb_Hotkeys.TabStop = false;
-			this.gb_Hotkeys.Text = "Hotkeys";
-			// 
-			// cb_QuitKey
-			// 
-			this.cb_QuitKey.DropDownHeight = 138;
-			this.cb_QuitKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb_QuitKey.FormattingEnabled = true;
-			this.cb_QuitKey.IntegralHeight = false;
-			this.cb_QuitKey.Items.AddRange(new object[] {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsWindow));
+            this.gb_Hotkeys = new System.Windows.Forms.GroupBox();
+            this.cb_QuitKey = new System.Windows.Forms.ComboBox();
+            this.cb_SettingsKey = new System.Windows.Forms.ComboBox();
+            this.cb_ToggleKey = new System.Windows.Forms.ComboBox();
+            this.cb_DecreaseKey = new System.Windows.Forms.ComboBox();
+            this.cb_IncreaseKey = new System.Windows.Forms.ComboBox();
+            this.cb_QuitAlt = new System.Windows.Forms.CheckBox();
+            this.cb_SettingsAlt = new System.Windows.Forms.CheckBox();
+            this.cb_ToggleAlt = new System.Windows.Forms.CheckBox();
+            this.cb_DecreaseAlt = new System.Windows.Forms.CheckBox();
+            this.cb_IncreaseAlt = new System.Windows.Forms.CheckBox();
+            this.cb_QuitShift = new System.Windows.Forms.CheckBox();
+            this.cb_SettingsShift = new System.Windows.Forms.CheckBox();
+            this.cb_ToggleShift = new System.Windows.Forms.CheckBox();
+            this.cb_DecreaseShift = new System.Windows.Forms.CheckBox();
+            this.cb_QuitCtrl = new System.Windows.Forms.CheckBox();
+            this.cb_SettingsCtrl = new System.Windows.Forms.CheckBox();
+            this.cb_ToggleCtrl = new System.Windows.Forms.CheckBox();
+            this.cb_DecreaseCtrl = new System.Windows.Forms.CheckBox();
+            this.cb_IncreaseShift = new System.Windows.Forms.CheckBox();
+            this.cb_IncreaseCtrl = new System.Windows.Forms.CheckBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.lb_Key = new System.Windows.Forms.Label();
+            this.lb_Alt = new System.Windows.Forms.Label();
+            this.lb_Shift = new System.Windows.Forms.Label();
+            this.lb_Ctrl = new System.Windows.Forms.Label();
+            this.lb_Increase = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.gb_General = new System.Windows.Forms.GroupBox();
+            this.label8 = new System.Windows.Forms.Label();
+            this.label9 = new System.Windows.Forms.Label();
+            this.lb_BrightnessLevel = new System.Windows.Forms.Label();
+            this.tb_BrightnessLevel = new System.Windows.Forms.TrackBar();
+            this.lb_FilterLevelMax = new System.Windows.Forms.Label();
+            this.lb_FilterLevelMin = new System.Windows.Forms.Label();
+            this.cb_Filter = new System.Windows.Forms.CheckBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.lb_FilterLevel = new System.Windows.Forms.Label();
+            this.tb_FilterLevel = new System.Windows.Forms.TrackBar();
+            this.gb_Hotkeys.SuspendLayout();
+            this.gb_General.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.tb_BrightnessLevel)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tb_FilterLevel)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // gb_Hotkeys
+            // 
+            this.gb_Hotkeys.Controls.Add(this.cb_QuitKey);
+            this.gb_Hotkeys.Controls.Add(this.cb_SettingsKey);
+            this.gb_Hotkeys.Controls.Add(this.cb_ToggleKey);
+            this.gb_Hotkeys.Controls.Add(this.cb_DecreaseKey);
+            this.gb_Hotkeys.Controls.Add(this.cb_IncreaseKey);
+            this.gb_Hotkeys.Controls.Add(this.cb_QuitAlt);
+            this.gb_Hotkeys.Controls.Add(this.cb_SettingsAlt);
+            this.gb_Hotkeys.Controls.Add(this.cb_ToggleAlt);
+            this.gb_Hotkeys.Controls.Add(this.cb_DecreaseAlt);
+            this.gb_Hotkeys.Controls.Add(this.cb_IncreaseAlt);
+            this.gb_Hotkeys.Controls.Add(this.cb_QuitShift);
+            this.gb_Hotkeys.Controls.Add(this.cb_SettingsShift);
+            this.gb_Hotkeys.Controls.Add(this.cb_ToggleShift);
+            this.gb_Hotkeys.Controls.Add(this.cb_DecreaseShift);
+            this.gb_Hotkeys.Controls.Add(this.cb_QuitCtrl);
+            this.gb_Hotkeys.Controls.Add(this.cb_SettingsCtrl);
+            this.gb_Hotkeys.Controls.Add(this.cb_ToggleCtrl);
+            this.gb_Hotkeys.Controls.Add(this.cb_DecreaseCtrl);
+            this.gb_Hotkeys.Controls.Add(this.cb_IncreaseShift);
+            this.gb_Hotkeys.Controls.Add(this.cb_IncreaseCtrl);
+            this.gb_Hotkeys.Controls.Add(this.label4);
+            this.gb_Hotkeys.Controls.Add(this.label3);
+            this.gb_Hotkeys.Controls.Add(this.label2);
+            this.gb_Hotkeys.Controls.Add(this.label1);
+            this.gb_Hotkeys.Controls.Add(this.lb_Key);
+            this.gb_Hotkeys.Controls.Add(this.lb_Alt);
+            this.gb_Hotkeys.Controls.Add(this.lb_Shift);
+            this.gb_Hotkeys.Controls.Add(this.lb_Ctrl);
+            this.gb_Hotkeys.Controls.Add(this.lb_Increase);
+            this.gb_Hotkeys.Controls.Add(this.label5);
+            this.gb_Hotkeys.Location = new System.Drawing.Point(12, 224);
+            this.gb_Hotkeys.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.gb_Hotkeys.Name = "gb_Hotkeys";
+            this.gb_Hotkeys.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.gb_Hotkeys.Size = new System.Drawing.Size(330, 237);
+            this.gb_Hotkeys.TabIndex = 1;
+            this.gb_Hotkeys.TabStop = false;
+            this.gb_Hotkeys.Text = "Hotkeys";
+            // 
+            // cb_QuitKey
+            // 
+            this.cb_QuitKey.DropDownHeight = 138;
+            this.cb_QuitKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb_QuitKey.FormattingEnabled = true;
+            this.cb_QuitKey.IntegralHeight = false;
+            this.cb_QuitKey.Items.AddRange(new object[] {
             "A",
             "B",
             "C",
@@ -170,19 +175,19 @@
             "F12",
             "Up",
             "Down"});
-			this.cb_QuitKey.Location = new System.Drawing.Point(250, 192);
-			this.cb_QuitKey.Name = "cb_QuitKey";
-			this.cb_QuitKey.Size = new System.Drawing.Size(61, 25);
-			this.cb_QuitKey.TabIndex = 19;
-			this.cb_QuitKey.SelectedIndexChanged += new System.EventHandler(this.QuitModifierChanged);
-			// 
-			// cb_SettingsKey
-			// 
-			this.cb_SettingsKey.DropDownHeight = 138;
-			this.cb_SettingsKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb_SettingsKey.FormattingEnabled = true;
-			this.cb_SettingsKey.IntegralHeight = false;
-			this.cb_SettingsKey.Items.AddRange(new object[] {
+            this.cb_QuitKey.Location = new System.Drawing.Point(250, 192);
+            this.cb_QuitKey.Name = "cb_QuitKey";
+            this.cb_QuitKey.Size = new System.Drawing.Size(61, 29);
+            this.cb_QuitKey.TabIndex = 19;
+            this.cb_QuitKey.SelectedIndexChanged += new System.EventHandler(this.QuitModifierChanged);
+            // 
+            // cb_SettingsKey
+            // 
+            this.cb_SettingsKey.DropDownHeight = 138;
+            this.cb_SettingsKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb_SettingsKey.FormattingEnabled = true;
+            this.cb_SettingsKey.IntegralHeight = false;
+            this.cb_SettingsKey.Items.AddRange(new object[] {
             "A",
             "B",
             "C",
@@ -233,19 +238,19 @@
             "F12",
             "Up",
             "Down"});
-			this.cb_SettingsKey.Location = new System.Drawing.Point(250, 161);
-			this.cb_SettingsKey.Name = "cb_SettingsKey";
-			this.cb_SettingsKey.Size = new System.Drawing.Size(61, 25);
-			this.cb_SettingsKey.TabIndex = 15;
-			this.cb_SettingsKey.SelectedIndexChanged += new System.EventHandler(this.SettingsModifierChanged);
-			// 
-			// cb_ToggleKey
-			// 
-			this.cb_ToggleKey.DropDownHeight = 138;
-			this.cb_ToggleKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb_ToggleKey.FormattingEnabled = true;
-			this.cb_ToggleKey.IntegralHeight = false;
-			this.cb_ToggleKey.Items.AddRange(new object[] {
+            this.cb_SettingsKey.Location = new System.Drawing.Point(250, 161);
+            this.cb_SettingsKey.Name = "cb_SettingsKey";
+            this.cb_SettingsKey.Size = new System.Drawing.Size(61, 29);
+            this.cb_SettingsKey.TabIndex = 15;
+            this.cb_SettingsKey.SelectedIndexChanged += new System.EventHandler(this.SettingsModifierChanged);
+            // 
+            // cb_ToggleKey
+            // 
+            this.cb_ToggleKey.DropDownHeight = 138;
+            this.cb_ToggleKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb_ToggleKey.FormattingEnabled = true;
+            this.cb_ToggleKey.IntegralHeight = false;
+            this.cb_ToggleKey.Items.AddRange(new object[] {
             "A",
             "B",
             "C",
@@ -296,19 +301,19 @@
             "F12",
             "Up",
             "Down"});
-			this.cb_ToggleKey.Location = new System.Drawing.Point(250, 130);
-			this.cb_ToggleKey.Name = "cb_ToggleKey";
-			this.cb_ToggleKey.Size = new System.Drawing.Size(61, 25);
-			this.cb_ToggleKey.TabIndex = 11;
-			this.cb_ToggleKey.SelectedIndexChanged += new System.EventHandler(this.ToggleModifierChanged);
-			// 
-			// cb_DecreaseKey
-			// 
-			this.cb_DecreaseKey.DropDownHeight = 138;
-			this.cb_DecreaseKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb_DecreaseKey.FormattingEnabled = true;
-			this.cb_DecreaseKey.IntegralHeight = false;
-			this.cb_DecreaseKey.Items.AddRange(new object[] {
+            this.cb_ToggleKey.Location = new System.Drawing.Point(250, 130);
+            this.cb_ToggleKey.Name = "cb_ToggleKey";
+            this.cb_ToggleKey.Size = new System.Drawing.Size(61, 29);
+            this.cb_ToggleKey.TabIndex = 11;
+            this.cb_ToggleKey.SelectedIndexChanged += new System.EventHandler(this.ToggleModifierChanged);
+            // 
+            // cb_DecreaseKey
+            // 
+            this.cb_DecreaseKey.DropDownHeight = 138;
+            this.cb_DecreaseKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb_DecreaseKey.FormattingEnabled = true;
+            this.cb_DecreaseKey.IntegralHeight = false;
+            this.cb_DecreaseKey.Items.AddRange(new object[] {
             "A",
             "B",
             "C",
@@ -359,19 +364,19 @@
             "F12",
             "Up",
             "Down"});
-			this.cb_DecreaseKey.Location = new System.Drawing.Point(250, 99);
-			this.cb_DecreaseKey.Name = "cb_DecreaseKey";
-			this.cb_DecreaseKey.Size = new System.Drawing.Size(61, 25);
-			this.cb_DecreaseKey.TabIndex = 7;
-			this.cb_DecreaseKey.SelectedIndexChanged += new System.EventHandler(this.DecreaseModifierChanged);
-			// 
-			// cb_IncreaseKey
-			// 
-			this.cb_IncreaseKey.DropDownHeight = 138;
-			this.cb_IncreaseKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cb_IncreaseKey.FormattingEnabled = true;
-			this.cb_IncreaseKey.IntegralHeight = false;
-			this.cb_IncreaseKey.Items.AddRange(new object[] {
+            this.cb_DecreaseKey.Location = new System.Drawing.Point(250, 99);
+            this.cb_DecreaseKey.Name = "cb_DecreaseKey";
+            this.cb_DecreaseKey.Size = new System.Drawing.Size(61, 29);
+            this.cb_DecreaseKey.TabIndex = 7;
+            this.cb_DecreaseKey.SelectedIndexChanged += new System.EventHandler(this.DecreaseModifierChanged);
+            // 
+            // cb_IncreaseKey
+            // 
+            this.cb_IncreaseKey.DropDownHeight = 138;
+            this.cb_IncreaseKey.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cb_IncreaseKey.FormattingEnabled = true;
+            this.cb_IncreaseKey.IntegralHeight = false;
+            this.cb_IncreaseKey.Items.AddRange(new object[] {
             "A",
             "B",
             "C",
@@ -422,350 +427,395 @@
             "F12",
             "Up",
             "Down"});
-			this.cb_IncreaseKey.Location = new System.Drawing.Point(250, 68);
-			this.cb_IncreaseKey.Name = "cb_IncreaseKey";
-			this.cb_IncreaseKey.Size = new System.Drawing.Size(61, 25);
-			this.cb_IncreaseKey.TabIndex = 3;
-			this.cb_IncreaseKey.SelectedIndexChanged += new System.EventHandler(this.IncreaseModifierChanged);
-			// 
-			// cb_QuitAlt
-			// 
-			this.cb_QuitAlt.AutoSize = true;
-			this.cb_QuitAlt.Location = new System.Drawing.Point(221, 197);
-			this.cb_QuitAlt.Name = "cb_QuitAlt";
-			this.cb_QuitAlt.Size = new System.Drawing.Size(15, 14);
-			this.cb_QuitAlt.TabIndex = 18;
-			this.cb_QuitAlt.UseVisualStyleBackColor = true;
-			this.cb_QuitAlt.CheckedChanged += new System.EventHandler(this.QuitModifierChanged);
-			// 
-			// cb_SettingsAlt
-			// 
-			this.cb_SettingsAlt.AutoSize = true;
-			this.cb_SettingsAlt.Location = new System.Drawing.Point(221, 166);
-			this.cb_SettingsAlt.Name = "cb_SettingsAlt";
-			this.cb_SettingsAlt.Size = new System.Drawing.Size(15, 14);
-			this.cb_SettingsAlt.TabIndex = 14;
-			this.cb_SettingsAlt.UseVisualStyleBackColor = true;
-			this.cb_SettingsAlt.CheckedChanged += new System.EventHandler(this.SettingsModifierChanged);
-			// 
-			// cb_ToggleAlt
-			// 
-			this.cb_ToggleAlt.AutoSize = true;
-			this.cb_ToggleAlt.Location = new System.Drawing.Point(221, 135);
-			this.cb_ToggleAlt.Name = "cb_ToggleAlt";
-			this.cb_ToggleAlt.Size = new System.Drawing.Size(15, 14);
-			this.cb_ToggleAlt.TabIndex = 10;
-			this.cb_ToggleAlt.UseVisualStyleBackColor = true;
-			this.cb_ToggleAlt.CheckedChanged += new System.EventHandler(this.ToggleModifierChanged);
-			// 
-			// cb_DecreaseAlt
-			// 
-			this.cb_DecreaseAlt.AutoSize = true;
-			this.cb_DecreaseAlt.Location = new System.Drawing.Point(221, 104);
-			this.cb_DecreaseAlt.Name = "cb_DecreaseAlt";
-			this.cb_DecreaseAlt.Size = new System.Drawing.Size(15, 14);
-			this.cb_DecreaseAlt.TabIndex = 6;
-			this.cb_DecreaseAlt.UseVisualStyleBackColor = true;
-			this.cb_DecreaseAlt.CheckedChanged += new System.EventHandler(this.DecreaseModifierChanged);
-			// 
-			// cb_IncreaseAlt
-			// 
-			this.cb_IncreaseAlt.AutoSize = true;
-			this.cb_IncreaseAlt.Location = new System.Drawing.Point(221, 73);
-			this.cb_IncreaseAlt.Name = "cb_IncreaseAlt";
-			this.cb_IncreaseAlt.Size = new System.Drawing.Size(15, 14);
-			this.cb_IncreaseAlt.TabIndex = 2;
-			this.cb_IncreaseAlt.UseVisualStyleBackColor = true;
-			this.cb_IncreaseAlt.CheckedChanged += new System.EventHandler(this.IncreaseModifierChanged);
-			// 
-			// cb_QuitShift
-			// 
-			this.cb_QuitShift.AutoSize = true;
-			this.cb_QuitShift.Location = new System.Drawing.Point(186, 197);
-			this.cb_QuitShift.Name = "cb_QuitShift";
-			this.cb_QuitShift.Size = new System.Drawing.Size(15, 14);
-			this.cb_QuitShift.TabIndex = 17;
-			this.cb_QuitShift.UseVisualStyleBackColor = true;
-			this.cb_QuitShift.CheckedChanged += new System.EventHandler(this.QuitModifierChanged);
-			// 
-			// cb_SettingsShift
-			// 
-			this.cb_SettingsShift.AutoSize = true;
-			this.cb_SettingsShift.Location = new System.Drawing.Point(186, 166);
-			this.cb_SettingsShift.Name = "cb_SettingsShift";
-			this.cb_SettingsShift.Size = new System.Drawing.Size(15, 14);
-			this.cb_SettingsShift.TabIndex = 13;
-			this.cb_SettingsShift.UseVisualStyleBackColor = true;
-			this.cb_SettingsShift.CheckedChanged += new System.EventHandler(this.SettingsModifierChanged);
-			// 
-			// cb_ToggleShift
-			// 
-			this.cb_ToggleShift.AutoSize = true;
-			this.cb_ToggleShift.Location = new System.Drawing.Point(186, 135);
-			this.cb_ToggleShift.Name = "cb_ToggleShift";
-			this.cb_ToggleShift.Size = new System.Drawing.Size(15, 14);
-			this.cb_ToggleShift.TabIndex = 9;
-			this.cb_ToggleShift.UseVisualStyleBackColor = true;
-			this.cb_ToggleShift.CheckedChanged += new System.EventHandler(this.ToggleModifierChanged);
-			// 
-			// cb_DecreaseShift
-			// 
-			this.cb_DecreaseShift.AutoSize = true;
-			this.cb_DecreaseShift.Location = new System.Drawing.Point(186, 104);
-			this.cb_DecreaseShift.Name = "cb_DecreaseShift";
-			this.cb_DecreaseShift.Size = new System.Drawing.Size(15, 14);
-			this.cb_DecreaseShift.TabIndex = 5;
-			this.cb_DecreaseShift.UseVisualStyleBackColor = true;
-			this.cb_DecreaseShift.CheckedChanged += new System.EventHandler(this.DecreaseModifierChanged);
-			// 
-			// cb_QuitCtrl
-			// 
-			this.cb_QuitCtrl.AutoSize = true;
-			this.cb_QuitCtrl.Location = new System.Drawing.Point(151, 197);
-			this.cb_QuitCtrl.Name = "cb_QuitCtrl";
-			this.cb_QuitCtrl.Size = new System.Drawing.Size(15, 14);
-			this.cb_QuitCtrl.TabIndex = 16;
-			this.cb_QuitCtrl.UseVisualStyleBackColor = true;
-			this.cb_QuitCtrl.CheckedChanged += new System.EventHandler(this.QuitModifierChanged);
-			// 
-			// cb_SettingsCtrl
-			// 
-			this.cb_SettingsCtrl.AutoSize = true;
-			this.cb_SettingsCtrl.Location = new System.Drawing.Point(151, 166);
-			this.cb_SettingsCtrl.Name = "cb_SettingsCtrl";
-			this.cb_SettingsCtrl.Size = new System.Drawing.Size(15, 14);
-			this.cb_SettingsCtrl.TabIndex = 12;
-			this.cb_SettingsCtrl.UseVisualStyleBackColor = true;
-			this.cb_SettingsCtrl.CheckedChanged += new System.EventHandler(this.SettingsModifierChanged);
-			// 
-			// cb_ToggleCtrl
-			// 
-			this.cb_ToggleCtrl.AutoSize = true;
-			this.cb_ToggleCtrl.Location = new System.Drawing.Point(151, 135);
-			this.cb_ToggleCtrl.Name = "cb_ToggleCtrl";
-			this.cb_ToggleCtrl.Size = new System.Drawing.Size(15, 14);
-			this.cb_ToggleCtrl.TabIndex = 8;
-			this.cb_ToggleCtrl.UseVisualStyleBackColor = true;
-			this.cb_ToggleCtrl.CheckedChanged += new System.EventHandler(this.ToggleModifierChanged);
-			// 
-			// cb_DecreaseCtrl
-			// 
-			this.cb_DecreaseCtrl.AutoSize = true;
-			this.cb_DecreaseCtrl.Location = new System.Drawing.Point(151, 104);
-			this.cb_DecreaseCtrl.Name = "cb_DecreaseCtrl";
-			this.cb_DecreaseCtrl.Size = new System.Drawing.Size(15, 14);
-			this.cb_DecreaseCtrl.TabIndex = 4;
-			this.cb_DecreaseCtrl.UseVisualStyleBackColor = true;
-			this.cb_DecreaseCtrl.CheckedChanged += new System.EventHandler(this.DecreaseModifierChanged);
-			// 
-			// cb_IncreaseShift
-			// 
-			this.cb_IncreaseShift.AutoSize = true;
-			this.cb_IncreaseShift.Location = new System.Drawing.Point(186, 73);
-			this.cb_IncreaseShift.Name = "cb_IncreaseShift";
-			this.cb_IncreaseShift.Size = new System.Drawing.Size(15, 14);
-			this.cb_IncreaseShift.TabIndex = 1;
-			this.cb_IncreaseShift.UseVisualStyleBackColor = true;
-			this.cb_IncreaseShift.CheckedChanged += new System.EventHandler(this.IncreaseModifierChanged);
-			// 
-			// cb_IncreaseCtrl
-			// 
-			this.cb_IncreaseCtrl.AutoSize = true;
-			this.cb_IncreaseCtrl.Location = new System.Drawing.Point(151, 73);
-			this.cb_IncreaseCtrl.Name = "cb_IncreaseCtrl";
-			this.cb_IncreaseCtrl.Size = new System.Drawing.Size(15, 14);
-			this.cb_IncreaseCtrl.TabIndex = 0;
-			this.cb_IncreaseCtrl.UseVisualStyleBackColor = true;
-			this.cb_IncreaseCtrl.CheckedChanged += new System.EventHandler(this.IncreaseModifierChanged);
-			// 
-			// label4
-			// 
-			this.label4.Location = new System.Drawing.Point(6, 195);
-			this.label4.Name = "label4";
-			this.label4.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.label4.Size = new System.Drawing.Size(134, 17);
-			this.label4.TabIndex = 0;
-			this.label4.Text = ":Quit from Penumbra";
-			// 
-			// label3
-			// 
-			this.label3.Location = new System.Drawing.Point(6, 164);
-			this.label3.Name = "label3";
-			this.label3.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.label3.Size = new System.Drawing.Size(134, 17);
-			this.label3.TabIndex = 0;
-			this.label3.Text = ":Show/Hide Settings";
-			// 
-			// label2
-			// 
-			this.label2.Location = new System.Drawing.Point(6, 133);
-			this.label2.Name = "label2";
-			this.label2.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.label2.Size = new System.Drawing.Size(134, 17);
-			this.label2.TabIndex = 0;
-			this.label2.Text = ":Toggle Filter";
-			// 
-			// label1
-			// 
-			this.label1.Location = new System.Drawing.Point(6, 102);
-			this.label1.Name = "label1";
-			this.label1.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.label1.Size = new System.Drawing.Size(134, 17);
-			this.label1.TabIndex = 0;
-			this.label1.Text = ":Decrease Filter Level";
-			// 
-			// lb_Key
-			// 
-			this.lb_Key.AutoSize = true;
-			this.lb_Key.Location = new System.Drawing.Point(266, 27);
-			this.lb_Key.Name = "lb_Key";
-			this.lb_Key.Size = new System.Drawing.Size(29, 17);
-			this.lb_Key.TabIndex = 0;
-			this.lb_Key.Text = "Key";
-			// 
-			// lb_Alt
-			// 
-			this.lb_Alt.AutoSize = true;
-			this.lb_Alt.Location = new System.Drawing.Point(217, 27);
-			this.lb_Alt.Name = "lb_Alt";
-			this.lb_Alt.Size = new System.Drawing.Size(23, 17);
-			this.lb_Alt.TabIndex = 0;
-			this.lb_Alt.Text = "Alt";
-			// 
-			// lb_Shift
-			// 
-			this.lb_Shift.AutoSize = true;
-			this.lb_Shift.Location = new System.Drawing.Point(177, 27);
-			this.lb_Shift.Name = "lb_Shift";
-			this.lb_Shift.Size = new System.Drawing.Size(33, 17);
-			this.lb_Shift.TabIndex = 0;
-			this.lb_Shift.Text = "Shift";
-			// 
-			// lb_Ctrl
-			// 
-			this.lb_Ctrl.AutoSize = true;
-			this.lb_Ctrl.Location = new System.Drawing.Point(143, 27);
-			this.lb_Ctrl.Name = "lb_Ctrl";
-			this.lb_Ctrl.Size = new System.Drawing.Size(28, 17);
-			this.lb_Ctrl.TabIndex = 0;
-			this.lb_Ctrl.Text = "Ctrl";
-			// 
-			// lb_Increase
-			// 
-			this.lb_Increase.Location = new System.Drawing.Point(6, 71);
-			this.lb_Increase.Name = "lb_Increase";
-			this.lb_Increase.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.lb_Increase.Size = new System.Drawing.Size(134, 17);
-			this.lb_Increase.TabIndex = 0;
-			this.lb_Increase.Text = ":Increase Filter Level";
-			// 
-			// label5
-			// 
-			this.label5.AutoSize = true;
-			this.label5.ForeColor = System.Drawing.SystemColors.ControlDark;
-			this.label5.Location = new System.Drawing.Point(6, 39);
-			this.label5.Name = "label5";
-			this.label5.Size = new System.Drawing.Size(308, 17);
-			this.label5.TabIndex = 21;
-			this.label5.Text = "____________________________________________________________";
-			// 
-			// gb_General
-			// 
-			this.gb_General.Controls.Add(this.lb_FilterLevelMax);
-			this.gb_General.Controls.Add(this.lb_FilterLevelMin);
-			this.gb_General.Controls.Add(this.cb_Filter);
-			this.gb_General.Controls.Add(this.label6);
-			this.gb_General.Controls.Add(this.lb_FilterLevel);
-			this.gb_General.Controls.Add(this.tb_FilterLevel);
-			this.gb_General.Location = new System.Drawing.Point(12, 12);
-			this.gb_General.Name = "gb_General";
-			this.gb_General.Size = new System.Drawing.Size(330, 104);
-			this.gb_General.TabIndex = 0;
-			this.gb_General.TabStop = false;
-			this.gb_General.Text = "General";
-			// 
-			// lb_FilterLevelMax
-			// 
-			this.lb_FilterLevelMax.AutoSize = true;
-			this.lb_FilterLevelMax.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
-			this.lb_FilterLevelMax.Location = new System.Drawing.Point(291, 76);
-			this.lb_FilterLevelMax.Name = "lb_FilterLevelMax";
-			this.lb_FilterLevelMax.Size = new System.Drawing.Size(34, 13);
-			this.lb_FilterLevelMax.TabIndex = 2;
-			this.lb_FilterLevelMax.Text = "100%";
-			// 
-			// lb_FilterLevelMin
-			// 
-			this.lb_FilterLevelMin.AutoSize = true;
-			this.lb_FilterLevelMin.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
-			this.lb_FilterLevelMin.Location = new System.Drawing.Point(146, 76);
-			this.lb_FilterLevelMin.Name = "lb_FilterLevelMin";
-			this.lb_FilterLevelMin.Size = new System.Drawing.Size(22, 13);
-			this.lb_FilterLevelMin.TabIndex = 2;
-			this.lb_FilterLevelMin.Text = "0%";
-			// 
-			// cb_Filter
-			// 
-			this.cb_Filter.AutoSize = true;
-			this.cb_Filter.Location = new System.Drawing.Point(149, 28);
-			this.cb_Filter.Name = "cb_Filter";
-			this.cb_Filter.Size = new System.Drawing.Size(15, 14);
-			this.cb_Filter.TabIndex = 0;
-			this.cb_Filter.UseVisualStyleBackColor = true;
-			this.cb_Filter.CheckedChanged += new System.EventHandler(this.cb_Filter_CheckedChanged);
-			// 
-			// label6
-			// 
-			this.label6.Location = new System.Drawing.Point(9, 26);
-			this.label6.Name = "label6";
-			this.label6.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.label6.Size = new System.Drawing.Size(134, 17);
-			this.label6.TabIndex = 0;
-			this.label6.Text = ":Filter Enable";
-			// 
-			// lb_FilterLevel
-			// 
-			this.lb_FilterLevel.Location = new System.Drawing.Point(9, 53);
-			this.lb_FilterLevel.Name = "lb_FilterLevel";
-			this.lb_FilterLevel.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-			this.lb_FilterLevel.Size = new System.Drawing.Size(134, 17);
-			this.lb_FilterLevel.TabIndex = 0;
-			this.lb_FilterLevel.Text = ":Filter Level";
-			// 
-			// tb_FilterLevel
-			// 
-			this.tb_FilterLevel.LargeChange = 10;
-			this.tb_FilterLevel.Location = new System.Drawing.Point(143, 53);
-			this.tb_FilterLevel.Maximum = 100;
-			this.tb_FilterLevel.Name = "tb_FilterLevel";
-			this.tb_FilterLevel.Size = new System.Drawing.Size(177, 45);
-			this.tb_FilterLevel.TabIndex = 1;
-			this.tb_FilterLevel.TickStyle = System.Windows.Forms.TickStyle.None;
-			this.tb_FilterLevel.Scroll += new System.EventHandler(this.tb_FilterLevel_Scroll);
-			// 
-			// SettingsWindow
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(354, 372);
-			this.Controls.Add(this.gb_General);
-			this.Controls.Add(this.gb_Hotkeys);
-			this.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "SettingsWindow";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-			this.Text = "Penumbra Settings";
-			this.Load += new System.EventHandler(this.SettingsWindow_Load);
-			this.gb_Hotkeys.ResumeLayout(false);
-			this.gb_Hotkeys.PerformLayout();
-			this.gb_General.ResumeLayout(false);
-			this.gb_General.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.tb_FilterLevel)).EndInit();
-			this.ResumeLayout(false);
+            this.cb_IncreaseKey.Location = new System.Drawing.Point(250, 68);
+            this.cb_IncreaseKey.Name = "cb_IncreaseKey";
+            this.cb_IncreaseKey.Size = new System.Drawing.Size(61, 29);
+            this.cb_IncreaseKey.TabIndex = 3;
+            this.cb_IncreaseKey.SelectedIndexChanged += new System.EventHandler(this.IncreaseModifierChanged);
+            // 
+            // cb_QuitAlt
+            // 
+            this.cb_QuitAlt.AutoSize = true;
+            this.cb_QuitAlt.Location = new System.Drawing.Point(221, 197);
+            this.cb_QuitAlt.Name = "cb_QuitAlt";
+            this.cb_QuitAlt.Size = new System.Drawing.Size(18, 17);
+            this.cb_QuitAlt.TabIndex = 18;
+            this.cb_QuitAlt.UseVisualStyleBackColor = true;
+            this.cb_QuitAlt.CheckedChanged += new System.EventHandler(this.QuitModifierChanged);
+            // 
+            // cb_SettingsAlt
+            // 
+            this.cb_SettingsAlt.AutoSize = true;
+            this.cb_SettingsAlt.Location = new System.Drawing.Point(221, 166);
+            this.cb_SettingsAlt.Name = "cb_SettingsAlt";
+            this.cb_SettingsAlt.Size = new System.Drawing.Size(18, 17);
+            this.cb_SettingsAlt.TabIndex = 14;
+            this.cb_SettingsAlt.UseVisualStyleBackColor = true;
+            this.cb_SettingsAlt.CheckedChanged += new System.EventHandler(this.SettingsModifierChanged);
+            // 
+            // cb_ToggleAlt
+            // 
+            this.cb_ToggleAlt.AutoSize = true;
+            this.cb_ToggleAlt.Location = new System.Drawing.Point(221, 135);
+            this.cb_ToggleAlt.Name = "cb_ToggleAlt";
+            this.cb_ToggleAlt.Size = new System.Drawing.Size(18, 17);
+            this.cb_ToggleAlt.TabIndex = 10;
+            this.cb_ToggleAlt.UseVisualStyleBackColor = true;
+            this.cb_ToggleAlt.CheckedChanged += new System.EventHandler(this.ToggleModifierChanged);
+            // 
+            // cb_DecreaseAlt
+            // 
+            this.cb_DecreaseAlt.AutoSize = true;
+            this.cb_DecreaseAlt.Location = new System.Drawing.Point(221, 104);
+            this.cb_DecreaseAlt.Name = "cb_DecreaseAlt";
+            this.cb_DecreaseAlt.Size = new System.Drawing.Size(18, 17);
+            this.cb_DecreaseAlt.TabIndex = 6;
+            this.cb_DecreaseAlt.UseVisualStyleBackColor = true;
+            this.cb_DecreaseAlt.CheckedChanged += new System.EventHandler(this.DecreaseModifierChanged);
+            // 
+            // cb_IncreaseAlt
+            // 
+            this.cb_IncreaseAlt.AutoSize = true;
+            this.cb_IncreaseAlt.Location = new System.Drawing.Point(221, 73);
+            this.cb_IncreaseAlt.Name = "cb_IncreaseAlt";
+            this.cb_IncreaseAlt.Size = new System.Drawing.Size(18, 17);
+            this.cb_IncreaseAlt.TabIndex = 2;
+            this.cb_IncreaseAlt.UseVisualStyleBackColor = true;
+            this.cb_IncreaseAlt.CheckedChanged += new System.EventHandler(this.IncreaseModifierChanged);
+            // 
+            // cb_QuitShift
+            // 
+            this.cb_QuitShift.AutoSize = true;
+            this.cb_QuitShift.Location = new System.Drawing.Point(186, 197);
+            this.cb_QuitShift.Name = "cb_QuitShift";
+            this.cb_QuitShift.Size = new System.Drawing.Size(18, 17);
+            this.cb_QuitShift.TabIndex = 17;
+            this.cb_QuitShift.UseVisualStyleBackColor = true;
+            this.cb_QuitShift.CheckedChanged += new System.EventHandler(this.QuitModifierChanged);
+            // 
+            // cb_SettingsShift
+            // 
+            this.cb_SettingsShift.AutoSize = true;
+            this.cb_SettingsShift.Location = new System.Drawing.Point(186, 166);
+            this.cb_SettingsShift.Name = "cb_SettingsShift";
+            this.cb_SettingsShift.Size = new System.Drawing.Size(18, 17);
+            this.cb_SettingsShift.TabIndex = 13;
+            this.cb_SettingsShift.UseVisualStyleBackColor = true;
+            this.cb_SettingsShift.CheckedChanged += new System.EventHandler(this.SettingsModifierChanged);
+            // 
+            // cb_ToggleShift
+            // 
+            this.cb_ToggleShift.AutoSize = true;
+            this.cb_ToggleShift.Location = new System.Drawing.Point(186, 135);
+            this.cb_ToggleShift.Name = "cb_ToggleShift";
+            this.cb_ToggleShift.Size = new System.Drawing.Size(18, 17);
+            this.cb_ToggleShift.TabIndex = 9;
+            this.cb_ToggleShift.UseVisualStyleBackColor = true;
+            this.cb_ToggleShift.CheckedChanged += new System.EventHandler(this.ToggleModifierChanged);
+            // 
+            // cb_DecreaseShift
+            // 
+            this.cb_DecreaseShift.AutoSize = true;
+            this.cb_DecreaseShift.Location = new System.Drawing.Point(186, 104);
+            this.cb_DecreaseShift.Name = "cb_DecreaseShift";
+            this.cb_DecreaseShift.Size = new System.Drawing.Size(18, 17);
+            this.cb_DecreaseShift.TabIndex = 5;
+            this.cb_DecreaseShift.UseVisualStyleBackColor = true;
+            this.cb_DecreaseShift.CheckedChanged += new System.EventHandler(this.DecreaseModifierChanged);
+            // 
+            // cb_QuitCtrl
+            // 
+            this.cb_QuitCtrl.AutoSize = true;
+            this.cb_QuitCtrl.Location = new System.Drawing.Point(151, 197);
+            this.cb_QuitCtrl.Name = "cb_QuitCtrl";
+            this.cb_QuitCtrl.Size = new System.Drawing.Size(18, 17);
+            this.cb_QuitCtrl.TabIndex = 16;
+            this.cb_QuitCtrl.UseVisualStyleBackColor = true;
+            this.cb_QuitCtrl.CheckedChanged += new System.EventHandler(this.QuitModifierChanged);
+            // 
+            // cb_SettingsCtrl
+            // 
+            this.cb_SettingsCtrl.AutoSize = true;
+            this.cb_SettingsCtrl.Location = new System.Drawing.Point(151, 166);
+            this.cb_SettingsCtrl.Name = "cb_SettingsCtrl";
+            this.cb_SettingsCtrl.Size = new System.Drawing.Size(18, 17);
+            this.cb_SettingsCtrl.TabIndex = 12;
+            this.cb_SettingsCtrl.UseVisualStyleBackColor = true;
+            this.cb_SettingsCtrl.CheckedChanged += new System.EventHandler(this.SettingsModifierChanged);
+            // 
+            // cb_ToggleCtrl
+            // 
+            this.cb_ToggleCtrl.AutoSize = true;
+            this.cb_ToggleCtrl.Location = new System.Drawing.Point(151, 135);
+            this.cb_ToggleCtrl.Name = "cb_ToggleCtrl";
+            this.cb_ToggleCtrl.Size = new System.Drawing.Size(18, 17);
+            this.cb_ToggleCtrl.TabIndex = 8;
+            this.cb_ToggleCtrl.UseVisualStyleBackColor = true;
+            this.cb_ToggleCtrl.CheckedChanged += new System.EventHandler(this.ToggleModifierChanged);
+            // 
+            // cb_DecreaseCtrl
+            // 
+            this.cb_DecreaseCtrl.AutoSize = true;
+            this.cb_DecreaseCtrl.Location = new System.Drawing.Point(151, 104);
+            this.cb_DecreaseCtrl.Name = "cb_DecreaseCtrl";
+            this.cb_DecreaseCtrl.Size = new System.Drawing.Size(18, 17);
+            this.cb_DecreaseCtrl.TabIndex = 4;
+            this.cb_DecreaseCtrl.UseVisualStyleBackColor = true;
+            this.cb_DecreaseCtrl.CheckedChanged += new System.EventHandler(this.DecreaseModifierChanged);
+            // 
+            // cb_IncreaseShift
+            // 
+            this.cb_IncreaseShift.AutoSize = true;
+            this.cb_IncreaseShift.Location = new System.Drawing.Point(186, 73);
+            this.cb_IncreaseShift.Name = "cb_IncreaseShift";
+            this.cb_IncreaseShift.Size = new System.Drawing.Size(18, 17);
+            this.cb_IncreaseShift.TabIndex = 1;
+            this.cb_IncreaseShift.UseVisualStyleBackColor = true;
+            this.cb_IncreaseShift.CheckedChanged += new System.EventHandler(this.IncreaseModifierChanged);
+            // 
+            // cb_IncreaseCtrl
+            // 
+            this.cb_IncreaseCtrl.AutoSize = true;
+            this.cb_IncreaseCtrl.Location = new System.Drawing.Point(151, 73);
+            this.cb_IncreaseCtrl.Name = "cb_IncreaseCtrl";
+            this.cb_IncreaseCtrl.Size = new System.Drawing.Size(18, 17);
+            this.cb_IncreaseCtrl.TabIndex = 0;
+            this.cb_IncreaseCtrl.UseVisualStyleBackColor = true;
+            this.cb_IncreaseCtrl.CheckedChanged += new System.EventHandler(this.IncreaseModifierChanged);
+            // 
+            // label4
+            // 
+            this.label4.Location = new System.Drawing.Point(6, 195);
+            this.label4.Name = "label4";
+            this.label4.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.label4.Size = new System.Drawing.Size(134, 17);
+            this.label4.TabIndex = 0;
+            this.label4.Text = ":Quit from Penumbra";
+            // 
+            // label3
+            // 
+            this.label3.Location = new System.Drawing.Point(6, 164);
+            this.label3.Name = "label3";
+            this.label3.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.label3.Size = new System.Drawing.Size(134, 17);
+            this.label3.TabIndex = 0;
+            this.label3.Text = ":Show/Hide Settings";
+            // 
+            // label2
+            // 
+            this.label2.Location = new System.Drawing.Point(6, 133);
+            this.label2.Name = "label2";
+            this.label2.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.label2.Size = new System.Drawing.Size(134, 17);
+            this.label2.TabIndex = 0;
+            this.label2.Text = ":Toggle Filter";
+            // 
+            // label1
+            // 
+            this.label1.Location = new System.Drawing.Point(6, 102);
+            this.label1.Name = "label1";
+            this.label1.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.label1.Size = new System.Drawing.Size(134, 17);
+            this.label1.TabIndex = 0;
+            this.label1.Text = ":Decrease Filter Level";
+            // 
+            // lb_Key
+            // 
+            this.lb_Key.AutoSize = true;
+            this.lb_Key.Location = new System.Drawing.Point(266, 27);
+            this.lb_Key.Name = "lb_Key";
+            this.lb_Key.Size = new System.Drawing.Size(37, 23);
+            this.lb_Key.TabIndex = 0;
+            this.lb_Key.Text = "Key";
+            // 
+            // lb_Alt
+            // 
+            this.lb_Alt.AutoSize = true;
+            this.lb_Alt.Location = new System.Drawing.Point(217, 27);
+            this.lb_Alt.Name = "lb_Alt";
+            this.lb_Alt.Size = new System.Drawing.Size(31, 23);
+            this.lb_Alt.TabIndex = 0;
+            this.lb_Alt.Text = "Alt";
+            // 
+            // lb_Shift
+            // 
+            this.lb_Shift.AutoSize = true;
+            this.lb_Shift.Location = new System.Drawing.Point(177, 27);
+            this.lb_Shift.Name = "lb_Shift";
+            this.lb_Shift.Size = new System.Drawing.Size(44, 23);
+            this.lb_Shift.TabIndex = 0;
+            this.lb_Shift.Text = "Shift";
+            // 
+            // lb_Ctrl
+            // 
+            this.lb_Ctrl.AutoSize = true;
+            this.lb_Ctrl.Location = new System.Drawing.Point(143, 27);
+            this.lb_Ctrl.Name = "lb_Ctrl";
+            this.lb_Ctrl.Size = new System.Drawing.Size(37, 23);
+            this.lb_Ctrl.TabIndex = 0;
+            this.lb_Ctrl.Text = "Ctrl";
+            // 
+            // lb_Increase
+            // 
+            this.lb_Increase.Location = new System.Drawing.Point(6, 71);
+            this.lb_Increase.Name = "lb_Increase";
+            this.lb_Increase.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.lb_Increase.Size = new System.Drawing.Size(134, 17);
+            this.lb_Increase.TabIndex = 0;
+            this.lb_Increase.Text = ":Increase Filter Level";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.ForeColor = System.Drawing.SystemColors.ControlDark;
+            this.label5.Location = new System.Drawing.Point(6, 39);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(430, 23);
+            this.label5.TabIndex = 21;
+            this.label5.Text = "____________________________________________________________";
+            // 
+            // gb_General
+            // 
+            this.gb_General.Controls.Add(this.label8);
+            this.gb_General.Controls.Add(this.label9);
+            this.gb_General.Controls.Add(this.lb_BrightnessLevel);
+            this.gb_General.Controls.Add(this.tb_BrightnessLevel);
+            this.gb_General.Controls.Add(this.lb_FilterLevelMax);
+            this.gb_General.Controls.Add(this.lb_FilterLevelMin);
+            this.gb_General.Controls.Add(this.cb_Filter);
+            this.gb_General.Controls.Add(this.label6);
+            this.gb_General.Controls.Add(this.lb_FilterLevel);
+            this.gb_General.Controls.Add(this.tb_FilterLevel);
+            this.gb_General.Location = new System.Drawing.Point(12, 12);
+            this.gb_General.Name = "gb_General";
+            this.gb_General.Size = new System.Drawing.Size(330, 161);
+            this.gb_General.TabIndex = 0;
+            this.gb_General.TabStop = false;
+            this.gb_General.Text = "General";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
+            this.label8.Location = new System.Drawing.Point(276, 126);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(44, 19);
+            this.label8.TabIndex = 4;
+            this.label8.Text = "100%";
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
+            this.label9.Location = new System.Drawing.Point(146, 126);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(28, 19);
+            this.label9.TabIndex = 5;
+            this.label9.Text = "0%";
+            // 
+            // lb_BrightnessLevel
+            // 
+            this.lb_BrightnessLevel.Location = new System.Drawing.Point(0, 98);
+            this.lb_BrightnessLevel.Name = "lb_BrightnessLevel";
+            this.lb_BrightnessLevel.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.lb_BrightnessLevel.Size = new System.Drawing.Size(134, 17);
+            this.lb_BrightnessLevel.TabIndex = 3;
+            this.lb_BrightnessLevel.Text = ":Brightness";
+            // 
+            // tb_BrightnessLevel
+            // 
+            this.tb_BrightnessLevel.LargeChange = 0;
+            this.tb_BrightnessLevel.Location = new System.Drawing.Point(143, 98);
+            this.tb_BrightnessLevel.Maximum = 100;
+            this.tb_BrightnessLevel.Name = "tb_BrightnessLevel";
+            this.tb_BrightnessLevel.Size = new System.Drawing.Size(177, 56);
+            this.tb_BrightnessLevel.TabIndex = 2;
+            this.tb_BrightnessLevel.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.tb_BrightnessLevel.Scroll += new System.EventHandler(this.tb_Brightness_Scroll);
+            // 
+            // lb_FilterLevelMax
+            // 
+            this.lb_FilterLevelMax.AutoSize = true;
+            this.lb_FilterLevelMax.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
+            this.lb_FilterLevelMax.Location = new System.Drawing.Point(276, 76);
+            this.lb_FilterLevelMax.Name = "lb_FilterLevelMax";
+            this.lb_FilterLevelMax.Size = new System.Drawing.Size(44, 19);
+            this.lb_FilterLevelMax.TabIndex = 2;
+            this.lb_FilterLevelMax.Text = "100%";
+            // 
+            // lb_FilterLevelMin
+            // 
+            this.lb_FilterLevelMin.AutoSize = true;
+            this.lb_FilterLevelMin.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
+            this.lb_FilterLevelMin.Location = new System.Drawing.Point(146, 76);
+            this.lb_FilterLevelMin.Name = "lb_FilterLevelMin";
+            this.lb_FilterLevelMin.Size = new System.Drawing.Size(28, 19);
+            this.lb_FilterLevelMin.TabIndex = 2;
+            this.lb_FilterLevelMin.Text = "0%";
+            // 
+            // cb_Filter
+            // 
+            this.cb_Filter.AutoSize = true;
+            this.cb_Filter.Location = new System.Drawing.Point(149, 28);
+            this.cb_Filter.Name = "cb_Filter";
+            this.cb_Filter.Size = new System.Drawing.Size(18, 17);
+            this.cb_Filter.TabIndex = 0;
+            this.cb_Filter.UseVisualStyleBackColor = true;
+            this.cb_Filter.CheckedChanged += new System.EventHandler(this.cb_Filter_CheckedChanged);
+            // 
+            // label6
+            // 
+            this.label6.Location = new System.Drawing.Point(9, 26);
+            this.label6.Name = "label6";
+            this.label6.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.label6.Size = new System.Drawing.Size(134, 17);
+            this.label6.TabIndex = 0;
+            this.label6.Text = ":Filter Enable";
+            // 
+            // lb_FilterLevel
+            // 
+            this.lb_FilterLevel.Location = new System.Drawing.Point(9, 53);
+            this.lb_FilterLevel.Name = "lb_FilterLevel";
+            this.lb_FilterLevel.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.lb_FilterLevel.Size = new System.Drawing.Size(134, 17);
+            this.lb_FilterLevel.TabIndex = 0;
+            this.lb_FilterLevel.Text = ":Filter Level";
+            // 
+            // tb_FilterLevel
+            // 
+            this.tb_FilterLevel.LargeChange = 10;
+            this.tb_FilterLevel.Location = new System.Drawing.Point(143, 53);
+            this.tb_FilterLevel.Maximum = 100;
+            this.tb_FilterLevel.Name = "tb_FilterLevel";
+            this.tb_FilterLevel.Size = new System.Drawing.Size(177, 56);
+            this.tb_FilterLevel.TabIndex = 1;
+            this.tb_FilterLevel.TickStyle = System.Windows.Forms.TickStyle.None;
+            this.tb_FilterLevel.Scroll += new System.EventHandler(this.tb_FilterLevel_Scroll);
+            // 
+            // SettingsWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 21F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(357, 474);
+            this.Controls.Add(this.gb_General);
+            this.Controls.Add(this.gb_Hotkeys);
+            this.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "SettingsWindow";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Penumbra Settings";
+            this.Load += new System.EventHandler(this.SettingsWindow_Load);
+            this.gb_Hotkeys.ResumeLayout(false);
+            this.gb_Hotkeys.PerformLayout();
+            this.gb_General.ResumeLayout(false);
+            this.gb_General.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.tb_BrightnessLevel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tb_FilterLevel)).EndInit();
+            this.ResumeLayout(false);
 
 		}
 
@@ -797,8 +847,7 @@
 		private System.Windows.Forms.Label lb_Shift;
 		private System.Windows.Forms.Label lb_Ctrl;
 		private System.Windows.Forms.Label label5;
-		private System.Windows.Forms.GroupBox gb_General;
-		private System.Windows.Forms.Label lb_FilterLevel;
+        private System.Windows.Forms.GroupBox gb_General;
 		private System.Windows.Forms.Label label6;
 		public System.Windows.Forms.TrackBar tb_FilterLevel;
 		public System.Windows.Forms.CheckBox cb_Filter;
@@ -809,6 +858,11 @@
 		private System.Windows.Forms.ComboBox cb_DecreaseKey;
 		private System.Windows.Forms.Label lb_FilterLevelMax;
 		private System.Windows.Forms.Label lb_FilterLevelMin;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label9;
+        public System.Windows.Forms.TrackBar tb_BrightnessLevel;
+        public System.Windows.Forms.Label lb_FilterLevel;
+        public System.Windows.Forms.Label lb_BrightnessLevel;
 
 
 

--- a/Windows/SettingsWindow.Designer.cs
+++ b/Windows/SettingsWindow.Designer.cs
@@ -715,7 +715,7 @@
             // 
             // lb_BrightnessLevel
             // 
-            this.lb_BrightnessLevel.Location = new System.Drawing.Point(0, 98);
+            this.lb_BrightnessLevel.Location = new System.Drawing.Point(9, 98);
             this.lb_BrightnessLevel.Name = "lb_BrightnessLevel";
             this.lb_BrightnessLevel.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.lb_BrightnessLevel.Size = new System.Drawing.Size(134, 17);

--- a/Windows/SettingsWindow.Designer.cs
+++ b/Windows/SettingsWindow.Designer.cs
@@ -109,7 +109,7 @@
             this.gb_Hotkeys.Controls.Add(this.lb_Ctrl);
             this.gb_Hotkeys.Controls.Add(this.lb_Increase);
             this.gb_Hotkeys.Controls.Add(this.label5);
-            this.gb_Hotkeys.Location = new System.Drawing.Point(12, 224);
+            this.gb_Hotkeys.Location = new System.Drawing.Point(12, 180);
             this.gb_Hotkeys.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.gb_Hotkeys.Name = "gb_Hotkeys";
             this.gb_Hotkeys.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
@@ -796,7 +796,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 21F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(357, 474);
+            this.ClientSize = new System.Drawing.Size(357, 430);
             this.Controls.Add(this.gb_General);
             this.Controls.Add(this.gb_Hotkeys);
             this.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(162)));

--- a/Windows/SettingsWindow.cs
+++ b/Windows/SettingsWindow.cs
@@ -60,6 +60,18 @@ namespace Penumbra.Windows
 			cb_QuitAlt.Checked = (Program.m_HotkeyQuit.Alt);
 			cb_QuitKey.Text = Program.m_HotkeyQuit.Key.ToString();
 
+            bool brightnessCapability = Monitors.brightnessCapability();
+            tb_BrightnessLevel.Enabled = brightnessCapability;
+            lb_BrightnessLevel.Enabled = brightnessCapability;
+
+            if(brightnessCapability){
+
+                tb_BrightnessLevel.Value = Monitors.getBrightness();
+            }
+            
+
+            lb_FilterLevel.Enabled = Program.Filtering;
+
 			InternalChangeInProgress = false;
 
 		}
@@ -115,6 +127,16 @@ namespace Penumbra.Windows
 			Program.SetBrightness(tb_FilterLevel.Value);
 
 		}
+
+        private void tb_Brightness_Scroll(object sender, EventArgs e)
+        {
+
+            if (InternalChangeInProgress)
+                return;
+
+            Monitors.setBrightness(tb_BrightnessLevel.Value);// (tb_BrightnessLevel.Value);
+
+        }
 
 		private void IncreaseModifierChanged(object sender, EventArgs e)
 		{

--- a/Windows/SettingsWindow.cs
+++ b/Windows/SettingsWindow.cs
@@ -60,13 +60,14 @@ namespace Penumbra.Windows
 			cb_QuitAlt.Checked = (Program.m_HotkeyQuit.Alt);
 			cb_QuitKey.Text = Program.m_HotkeyQuit.Key.ToString();
 
-            bool brightnessCapability = Monitors.brightnessCapability();
+            bool brightnessCapability = Monitors.Instance.HasBrightnessCapability();
+
             tb_BrightnessLevel.Enabled = brightnessCapability;
             lb_BrightnessLevel.Enabled = brightnessCapability;
 
             if(brightnessCapability){
 
-                tb_BrightnessLevel.Value = Monitors.getBrightness();
+                tb_BrightnessLevel.Value = Monitors.Instance.GetBrightness();
             }
             
 
@@ -114,7 +115,6 @@ namespace Penumbra.Windows
 
 			Program.ToggleFilter();
 
-			tb_FilterLevel.Enabled = Program.Filtering;
 
 		}
 
@@ -134,7 +134,7 @@ namespace Penumbra.Windows
             if (InternalChangeInProgress)
                 return;
 
-            Monitors.setBrightness(tb_BrightnessLevel.Value);// (tb_BrightnessLevel.Value);
+            Monitors.Instance.SetBrightness(tb_BrightnessLevel.Value);
 
         }
 


### PR DESCRIPTION
Added a new slider to control the brightness of all the connected monitors. No hotkeys options for the moment.

The Class Brightness was rename to Filter.

It was tested only on:
- Windows 10 with two LCD
- Windows 7 with one LCD

![penumbra](https://cloud.githubusercontent.com/assets/4369311/14063174/af499608-f392-11e5-9970-ab4008d2cfd2.jpg)
